### PR TITLE
Introduce async permission API

### DIFF
--- a/src/FluentAuthorization/Abstractions.Internal/IPermission.cs
+++ b/src/FluentAuthorization/Abstractions.Internal/IPermission.cs
@@ -15,4 +15,20 @@
     {
         
     }
+
+    /// <summary>
+    /// Abstraction of an async permission. Internal marker interface, not intended for implementation.
+    /// </summary>
+    public interface IAsyncPermission
+    {
+        
+    }
+
+    /// <summary>
+    /// Abstraction of an async permission with state. Internal marker interface, not intended for implementation.
+    /// </summary>
+    public interface IAsyncPermission<TState>
+    {
+        
+    }
 }

--- a/src/FluentAuthorization/Policy/Policy.AssertionContext.cs
+++ b/src/FluentAuthorization/Policy/Policy.AssertionContext.cs
@@ -11,6 +11,7 @@ namespace FluentAuthorization
         public class AssertionContext : AssertionContextBase
         {
             private readonly IPermission permission;
+            private readonly IAsyncPermission asyncPermission;
 
             internal AssertionContext(TUser user, TResource resource, TData data, IPermission permission, string policyName) 
                 : base(user, resource, data, permission.Name, policyName)
@@ -18,8 +19,23 @@ namespace FluentAuthorization
                 this.permission = permission;
             }
 
+            internal AssertionContext(TUser user, TResource resource, TData data, IAsyncPermission asyncPermission, string policyName) 
+                : base(user, resource, data, asyncPermission.Name, policyName)
+            {
+                this.asyncPermission = asyncPermission;
+            }
+
             private AssertionFailure BuildFailure(string reason)
-                => new (User.ToString(), PermissionName, PolicyName, permission.BuildMessage(this), reason);
+                => new (User.ToString(), PermissionName, PolicyName, BuildMessageInternal(), reason);
+
+            private string BuildMessageInternal()
+            {
+                if (permission != null)
+                    return permission.BuildMessage(this);
+                if (asyncPermission != null)
+                    return asyncPermission.BuildMessage(this);
+                return string.Empty;
+            }
 
             /// <summary>
             /// Produces a Deny result with the specified reason.

--- a/src/FluentAuthorization/Policy/Policy.AssertionContext_TState.cs
+++ b/src/FluentAuthorization/Policy/Policy.AssertionContext_TState.cs
@@ -11,6 +11,7 @@ namespace FluentAuthorization
         public class AssertionContext<TState> : AssertionContextBase
         {
             private readonly IPermission<TState> permission;
+            private readonly IAsyncPermission<TState> asyncPermission;
 
             internal AssertionContext(TUser user, TResource resource, TData data, TState state, IPermission<TState> permission, string policyName)
                 : base(user, resource, data, permission.Name, policyName)
@@ -19,10 +20,26 @@ namespace FluentAuthorization
                 this.permission = permission;
             }
 
+            internal AssertionContext(TUser user, TResource resource, TData data, TState state, IAsyncPermission<TState> asyncPermission, string policyName)
+                : base(user, resource, data, asyncPermission.Name, policyName)
+            {
+                State = state;
+                this.asyncPermission = asyncPermission;
+            }
+
             public TState State { get; }
 
             private AssertionFailure BuildFailure(string reason)
-                => new AssertionFailure(User.ToString(), PermissionName, PolicyName, permission.BuildMessage(this), reason);
+                => new AssertionFailure(User.ToString(), PermissionName, PolicyName, BuildMessageInternal(), reason);
+
+            private string BuildMessageInternal()
+            {
+                if (permission != null)
+                    return permission.BuildMessage(this);
+                if (asyncPermission != null)
+                    return asyncPermission.BuildMessage(this);
+                return string.Empty;
+            }
 
             /// <summary>
             /// Produces a Deny result with the specified reason.

--- a/src/FluentAuthorization/Policy/Policy.AsyncPermission.cs
+++ b/src/FluentAuthorization/Policy/Policy.AsyncPermission.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+
+namespace FluentAuthorization
+{
+    public abstract partial class Policy<TUser, TResource, TData>
+    {
+        internal interface IAsyncPermission
+        {
+            Task<AssertionResult> AssertAsync(AssertionContext context);
+            string BuildMessage(AssertionContext context);
+            string Name { get; }
+        }
+
+        /// <summary>
+        /// Abstract asynchronous policy permission. Inherit from this class to define your own async permission classes if you opt out using the inline delegate based permission builder.
+        /// </summary>
+        public abstract class AsyncPermission : FluentAuthorization.IAsyncPermission, IAsyncPermission
+        {
+            protected abstract Task<AssertionResult> AssertAsync(AssertionContext context);
+            protected abstract string BuildMessage(AssertionContext context);
+            public abstract string Name { get; }
+
+            public override string ToString() => Name;
+
+            Task<AssertionResult> IAsyncPermission.AssertAsync(AssertionContext context) => AssertAsync(context);
+            string IAsyncPermission.BuildMessage(AssertionContext context) => BuildMessage(context);
+        }
+    }
+}

--- a/src/FluentAuthorization/Policy/Policy.AsyncPermission_TState.cs
+++ b/src/FluentAuthorization/Policy/Policy.AsyncPermission_TState.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+
+namespace FluentAuthorization
+{
+    public abstract partial class Policy<TUser, TResource, TData>
+    {
+        internal interface IAsyncPermission<TState>
+        {
+            Task<AssertionResult> AssertAsync(AssertionContext<TState> context);
+            string BuildMessage(AssertionContext<TState> context);
+            string Name { get; }
+        }
+
+        /// <summary>
+        /// Abstract asynchronous policy permission with an input state. Inherit from this class to define your own async permission classes if you opt out using the inline delegate based permission builder.
+        /// </summary>
+        public abstract class AsyncPermission<TState> : FluentAuthorization.IAsyncPermission<TState>, IAsyncPermission<TState>
+        {
+            protected abstract Task<AssertionResult> AssertAsync(AssertionContext<TState> context);
+            protected abstract string BuildMessage(AssertionContext<TState> context);
+            public abstract string Name { get; }
+
+            public override string ToString() => Name;
+
+            Task<AssertionResult> IAsyncPermission<TState>.AssertAsync(AssertionContext<TState> context) => AssertAsync(context);
+            string IAsyncPermission<TState>.BuildMessage(AssertionContext<TState> context) => BuildMessage(context);
+        }
+    }
+}

--- a/src/FluentAuthorization/Policy/Policy.InlineAsyncPermission.cs
+++ b/src/FluentAuthorization/Policy/Policy.InlineAsyncPermission.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+
+namespace FluentAuthorization
+{
+    public abstract partial class Policy<TUser, TResource, TData>
+    {
+        internal class InlineAsyncPermission : AsyncPermission
+        {
+            private readonly Func<AssertionContext, Task<AssertionResult>> assertAsync;
+            private readonly Func<AssertionContext, string> messageBuilder;
+            
+            public InlineAsyncPermission(
+                Func<AssertionContext, Task<AssertionResult>> assertAsync,
+                string name,
+                Func<AssertionContext, string> messageBuilder)
+            {
+                this.assertAsync = assertAsync;
+                this.messageBuilder = messageBuilder ?? BuildDefaultMessage;
+                Name = name;
+            }
+
+            public override string Name { get; }
+
+            protected override Task<AssertionResult> AssertAsync(AssertionContext context)
+                => assertAsync(context);
+
+            protected override string BuildMessage(AssertionContext context)
+                => messageBuilder(context);
+        }
+    }
+}

--- a/src/FluentAuthorization/Policy/Policy.InlineAsyncPermission_TState.cs
+++ b/src/FluentAuthorization/Policy/Policy.InlineAsyncPermission_TState.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+
+namespace FluentAuthorization
+{
+    public abstract partial class Policy<TUser, TResource, TData>
+    {
+        internal class InlineAsyncPermission<TState> : AsyncPermission<TState>
+        {
+            private readonly Func<AssertionContext<TState>, Task<AssertionResult>> assertAsync;
+            private readonly Func<AssertionContext<TState>, string> messageBuilder;
+
+            public override string Name { get; }
+
+            public InlineAsyncPermission(
+                Func<AssertionContext<TState>, Task<AssertionResult>> assertAsync,
+                string name,
+                Func<AssertionContext<TState>, string> messageBuilder)
+            {
+                this.assertAsync = assertAsync;
+                this.messageBuilder = messageBuilder ?? BuildDefaultMessage;
+                Name = name;
+            }
+
+            protected override Task<AssertionResult> AssertAsync(AssertionContext<TState> context)
+                => assertAsync(context);
+
+            protected override string BuildMessage(AssertionContext<TState> context)
+                => messageBuilder(context);
+        }
+    }
+}

--- a/src/FluentAuthorization/Policy/Policy.PermissionBuilder.cs
+++ b/src/FluentAuthorization/Policy/Policy.PermissionBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace FluentAuthorization
 {
@@ -72,6 +73,76 @@ namespace FluentAuthorization
             public StatefullPermissionBuilder<TState> AssertWith<TState>(Func<AssertionContext<TState>, bool?> assert)
             {
                 return new StatefullPermissionBuilder<TState>(ctx => assert(ctx) switch
+                {
+                    true => ctx.Allow(),
+                    false => ctx.Deny(),
+                    _ => ctx.Undefined()
+                });
+            }
+
+            /// <summary>
+            /// Defines the asynchronous permission assertion logic for a stateless permission.
+            /// </summary>
+            /// <param name="assertAsync">The async assertion function.</param>
+            /// <returns></returns>
+            public StatelessAsyncPermissionBuilder AssertWithAsync(Func<AssertionContext, Task<AssertionResult>> assertAsync)
+            {
+                return new StatelessAsyncPermissionBuilder(assertAsync);
+            }
+
+            /// <summary>
+            /// Defines the asynchronous permission assertion logic for a stateless permission.
+            /// </summary>
+            /// <param name="assertAsync">The async assertion function.</param>
+            /// <returns></returns>
+            public StatelessAsyncPermissionBuilder AssertWithAsync(Func<AssertionContext, Task<bool>> assertAsync)
+            {
+                return new StatelessAsyncPermissionBuilder(async ctx => await assertAsync(ctx) ? ctx.Allow() : ctx.Deny());
+            }
+
+            /// <summary>
+            /// Defines the asynchronous permission assertion logic for a stateless permission.
+            /// </summary>
+            /// <param name="assertAsync">The async assertion function.</param>
+            /// <returns></returns>
+            public StatelessAsyncPermissionBuilder AssertWithAsync(Func<AssertionContext, Task<bool?>> assertAsync)
+            {
+                return new StatelessAsyncPermissionBuilder(async ctx => (await assertAsync(ctx)) switch
+                {
+                    true => ctx.Allow(),
+                    false => ctx.Deny(),
+                    _ => ctx.Undefined()
+                });
+            }
+
+            /// <summary>
+            /// Defines the asynchronous permission assertion logic for a statefull permission.
+            /// </summary>
+            /// <param name="assertAsync">The async assertion function.</param>
+            /// <returns></returns>
+            public StatefullAsyncPermissionBuilder<TState> AssertWithAsync<TState>(Func<AssertionContext<TState>, Task<AssertionResult>> assertAsync)
+            {
+                return new StatefullAsyncPermissionBuilder<TState>(assertAsync);
+            }
+
+            /// <summary>
+            /// Defines the asynchronous permission assertion logic for a statefull permission.
+            /// </summary>
+            /// <param name="assertAsync">The async assertion function.</param>
+            /// <returns></returns>
+            public StatefullAsyncPermissionBuilder<TState> AssertWithAsync<TState>(Func<AssertionContext<TState>, Task<bool>> assertAsync)
+            {
+                return new StatefullAsyncPermissionBuilder<TState>(async ctx => await assertAsync(ctx) ? ctx.Allow() : ctx.Deny());
+            }
+
+            /// <summary>
+            /// Defines the asynchronous permission assertion logic for a statefull permission.
+            /// </summary>
+            /// <param name="assertAsync">The async assertion function.</param>
+            /// <returns></returns>
+            public StatefullAsyncPermissionBuilder<TState> AssertWithAsync<TState>(Func<AssertionContext<TState>, Task<bool?>> assertAsync)
+            {
+                return new StatefullAsyncPermissionBuilder<TState>(async ctx => (await assertAsync(ctx)) switch
                 {
                     true => ctx.Allow(),
                     false => ctx.Deny(),

--- a/src/FluentAuthorization/Policy/Policy.StatefullAsyncPermissionBuilder.cs
+++ b/src/FluentAuthorization/Policy/Policy.StatefullAsyncPermissionBuilder.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading.Tasks;
+
+namespace FluentAuthorization
+{
+    public abstract partial class Policy<TUser, TResource, TData>
+    {
+        public class StatefullAsyncPermissionBuilder<TState>
+        {
+            private readonly Func<AssertionContext<TState>, Task<AssertionResult>> assertAsync;
+            private Func<AssertionContext<TState>, string> messageBuilder;
+            private string name;
+
+            internal StatefullAsyncPermissionBuilder(Func<AssertionContext<TState>, Task<AssertionResult>> assertAsync)
+            {
+                this.assertAsync = assertAsync;
+            }
+
+            /// <summary>
+            /// Defines the name of the permission reported in failure results.
+            /// </summary>
+            /// <param name="name">The selected name.</param>
+            /// <returns></returns>
+            public StatefullAsyncPermissionBuilder<TState> WithName(string name)
+            {
+                this.name = name;
+                return this;
+            }
+
+            /// <summary>
+            /// Overrides the default assertion failure message.
+            /// </summary>
+            /// <param name="messageBuilder">The message builder function.</param>
+            /// <returns></returns>
+            public StatefullAsyncPermissionBuilder<TState> WithMessage(Func<AssertionContext<TState>, string> messageBuilder)
+            {
+                this.messageBuilder = messageBuilder;
+                return this;
+            }
+
+            /// <summary>
+            /// Builds the async permission.
+            /// </summary>
+            /// <returns></returns>
+            public AsyncPermission<TState> Build()
+                => new InlineAsyncPermission<TState>(assertAsync, name, messageBuilder);
+        }
+    }
+}

--- a/src/FluentAuthorization/Policy/Policy.StatelessAsyncPermissionBuilder.cs
+++ b/src/FluentAuthorization/Policy/Policy.StatelessAsyncPermissionBuilder.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading.Tasks;
+
+namespace FluentAuthorization
+{
+    public abstract partial class Policy<TUser, TResource, TData>
+    {
+        public class StatelessAsyncPermissionBuilder
+        {
+            private readonly Func<AssertionContext, Task<AssertionResult>> assertAsync;
+            private Func<AssertionContext, string> messageBuilder;
+            private string name;
+
+            public StatelessAsyncPermissionBuilder(Func<AssertionContext, Task<AssertionResult>> assertAsync)
+            {
+                this.assertAsync = assertAsync;
+            }
+
+            /// <summary>
+            /// Defines the name of the permission reported in failure results.
+            /// </summary>
+            /// <param name="name">The selected name.</param>
+            /// <returns></returns>
+            public StatelessAsyncPermissionBuilder WithName(string name)
+            {
+                this.name = name;
+                return this;
+            }
+
+            /// <summary>
+            /// Overrides the default assertion failure message.
+            /// </summary>
+            /// <param name="messageBuilder">The message builder function.</param>
+            /// <returns></returns>
+            public StatelessAsyncPermissionBuilder WithMessage(Func<AssertionContext, string> messageBuilder)
+            {
+                this.messageBuilder = messageBuilder;
+                return this;
+            }
+
+            /// <summary>
+            /// Builds the async permission.
+            /// </summary>
+            /// <returns></returns>
+            public AsyncPermission Build()
+                => new InlineAsyncPermission(assertAsync, name, messageBuilder);
+        }
+    }
+}

--- a/src/FluentAuthorization/Policy/Policy.cs
+++ b/src/FluentAuthorization/Policy/Policy.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace FluentAuthorization
 {
@@ -88,6 +89,40 @@ namespace FluentAuthorization
             if (overridenResult is not null) return overridenResult;
 
             var results = data.Select(d => permission.Assert(new AssertionContext<TState>(user, resource, d, state, permission, Name))).ToList();
+
+            return AggregateAssertionsInternal(user.ToString(), permission.Name, results);
+        }
+
+        internal async Task<AssertionResult> AssertAsync(TUser user, TResource resource, IAsyncPermission permission, IEnumerable<TData> data)
+        {
+            data = AggregateDataInternal(data);
+
+            var overridenResult = OverrideAssertion(user, resource, permission.Name, data);
+            if (overridenResult is not null) return overridenResult;
+
+            var results = new List<AssertionResult>();
+            foreach (var d in data)
+            {
+                var result = await permission.AssertAsync(new AssertionContext(user, resource, d, permission, Name));
+                results.Add(result);
+            }
+
+            return AggregateAssertionsInternal(user.ToString(), permission.Name, results);
+        }
+
+        internal async Task<AssertionResult> AssertAsync<TState>(TUser user, TResource resource, IAsyncPermission<TState> permission, IEnumerable<TData> data, TState state)
+        {
+            data = AggregateDataInternal(data);
+
+            var overridenResult = OverrideAssertion(user, resource, permission.Name, data);
+            if (overridenResult is not null) return overridenResult;
+
+            var results = new List<AssertionResult>();
+            foreach (var d in data)
+            {
+                var result = await permission.AssertAsync(new AssertionContext<TState>(user, resource, d, state, permission, Name));
+                results.Add(result);
+            }
 
             return AggregateAssertionsInternal(user.ToString(), permission.Name, results);
         }

--- a/src/FluentAuthorization/Policy/PolicyReflector.cs
+++ b/src/FluentAuthorization/Policy/PolicyReflector.cs
@@ -10,8 +10,10 @@ namespace FluentAuthorization
     /// </summary>
     internal static class PolicyReflector
     {
-        private static System.Collections.Concurrent.ConcurrentDictionary<Type, IReadOnlyDictionary<string, Func<IPolicy, IPermission>>> statelessPermissions = new();
-        private static System.Collections.Concurrent.ConcurrentDictionary<Type, IReadOnlyDictionary<string, (Type stateType, Delegate getter)>> statefullPermissions = new();
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, IReadOnlyDictionary<string, Func<IPolicy, IPermission>>> statelessPermissions = new();
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, IReadOnlyDictionary<string, (Type stateType, Delegate getter)>> statefullPermissions = new();
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, IReadOnlyDictionary<string, Func<IPolicy, IAsyncPermission>>> statelessAsyncPermissions = new();
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, IReadOnlyDictionary<string, (Type stateType, Delegate getter)>> statefullAsyncPermissions = new();
 
         /// <summary>
         /// Gets a stateless permission from a policy object using the permission's property name.
@@ -33,7 +35,7 @@ namespace FluentAuthorization
                 .GetProperties(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public)
                 .Where(x => x.CanRead)
                 .Where(x => typeof(Policy<TUser, TResource, TData>.Permission).IsAssignableFrom(x.PropertyType))
-                .ToDictionary(x => x.Name, x => buildGetter(policyType, x)));
+                .ToDictionary(x => x.Name, x => buildGetter(type, x)));
 
             if (properties.TryGetValue(permissionName, out var getter))
                 return getter(policy);
@@ -71,13 +73,101 @@ namespace FluentAuthorization
                 .GetProperties(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public)
                 .Where(x => x.CanRead)
                 .Where(x => IsAssignableToGenericType(x.PropertyType, typeof(Policy<,,>.Permission<>), new[] { typeof(TUser), typeof(TResource),typeof(TData) }))
-                .ToDictionary(x => x.Name, x => (x.PropertyType.GetGenericArguments().Last(), (Delegate)buildGetter(policyType, x))));
+                .ToDictionary(x => x.Name, x => (x.PropertyType.GetGenericArguments().Last(), (Delegate)buildGetter(type, x))));
 
             if (properties.TryGetValue(permissionName, out var getter)
                 && getter.stateType == typeof(TState))
                 return (IPermission<TState>)((Func<IPolicy, object>)getter.getter)(policy);
 
             throw new ArgumentException($"Policy '{policy.Name}' of type '{policyType}' does not contain a Permission property '{permissionName}' with state type '{typeof(TState)}'.", nameof(permissionName));
+
+            static Func<IPolicy, object> buildGetter(Type policyType, System.Reflection.PropertyInfo property)
+            {
+                var parameter = Expression.Parameter(typeof(IPolicy));
+                var castedParameter = Expression.Convert(parameter, policyType);
+                var body = Expression.Property(castedParameter, property);
+                var castedResult = Expression.Convert(body, typeof(object));
+                return Expression.Lambda<Func<IPolicy, object>>(castedResult, parameter).Compile();
+            }
+
+            static bool IsAssignableToGenericType(Type givenType, Type genericType, Type[] typeArguments)
+            {
+                if (givenType.IsGenericType && givenType.GetGenericTypeDefinition() == genericType
+                    && typeArguments.SequenceEqual(givenType.GenericTypeArguments.Take(typeArguments.Length)))
+                    return true;
+
+                Type baseType = givenType.BaseType;
+                if (baseType == null) return false;
+
+                return IsAssignableToGenericType(baseType, genericType, typeArguments);
+            }
+        }
+
+        /// <summary>
+        /// Gets a stateless async permission from a policy object using the permission's property name.
+        /// </summary>
+        /// <typeparam name="TPolicy">The type of policy.</typeparam>
+        /// <typeparam name="TUser">The type of user context.</typeparam>
+        /// <typeparam name="TResource">The type of resource.</typeparam>
+        /// <typeparam name="TData">The policy data type.</typeparam>
+        /// <param name="policy">The given policy.</param>
+        /// <param name="permissionName">The permission's property name.</param>
+        /// <returns>The async permission with the given name.</returns>
+        /// <exception cref="ArgumentException">Thrown when there is no matching property on the policy object.</exception>
+        public static IAsyncPermission GetAsyncPermission<TPolicy, TUser, TResource, TData>(TPolicy policy, string permissionName)
+            where TPolicy : Policy<TUser, TResource, TData>
+        {
+            var policyType = policy.GetType();
+
+            var properties = statelessAsyncPermissions.GetOrAdd(policyType, type => type
+                .GetProperties(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public)
+                .Where(x => x.CanRead)
+                .Where(x => typeof(Policy<TUser, TResource, TData>.AsyncPermission).IsAssignableFrom(x.PropertyType))
+                .ToDictionary(x => x.Name, x => buildGetter(type, x)));
+
+            if (properties.TryGetValue(permissionName, out var getter))
+                return getter(policy);
+
+            throw new ArgumentException($"Policy '{policy.Name}' of type '{policyType}' does not contain an AsyncPermission property '{permissionName}'.", nameof(permissionName));
+
+            static Func<IPolicy, IAsyncPermission> buildGetter(Type policyType, System.Reflection.PropertyInfo property)
+            {
+                var parameter = Expression.Parameter(typeof(IPolicy));
+                var castedParameter = Expression.Convert(parameter, policyType);
+                var body = Expression.Property(castedParameter, property);
+                var castedResult = Expression.Convert(body, typeof(IAsyncPermission));
+                return Expression.Lambda<Func<IPolicy, IAsyncPermission>>(castedResult, parameter).Compile();
+            }
+        }
+
+        /// <summary>
+        /// Gets a statefull async permission from a policy object using the permission's property name.
+        /// </summary>
+        /// <typeparam name="TPolicy">The type of policy.</typeparam>
+        /// <typeparam name="TUser">The type of user context.</typeparam>
+        /// <typeparam name="TResource">The type of resource.</typeparam>
+        /// <typeparam name="TData">The policy data type.</typeparam>
+        /// <typeparam name="TState">The permission's state type.</typeparam>
+        /// <param name="policy">The given policy.</param>
+        /// <param name="permissionName">The permission's property name.</param>
+        /// <returns>The async permission with the given name.</returns>
+        /// <exception cref="ArgumentException">Thrown when there is no matching property on the policy object.</exception>
+        public static IAsyncPermission<TState> GetAsyncPermission<TPolicy, TUser, TResource, TData, TState>(TPolicy policy, string permissionName)
+            where TPolicy : Policy<TUser, TResource, TData>
+        {
+            var policyType = policy.GetType();
+            
+            var properties = statefullAsyncPermissions.GetOrAdd(policyType, type => type
+                .GetProperties(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public)
+                .Where(x => x.CanRead)
+                .Where(x => IsAssignableToGenericType(x.PropertyType, typeof(Policy<,,>.AsyncPermission<>), new[] { typeof(TUser), typeof(TResource), typeof(TData) }))
+                .ToDictionary(x => x.Name, x => (x.PropertyType.GetGenericArguments().Last(), (Delegate)buildGetter(type, x))));
+
+            if (properties.TryGetValue(permissionName, out var getter)
+                && getter.stateType == typeof(TState))
+                return (IAsyncPermission<TState>)((Func<IPolicy, object>)getter.getter)(policy);
+
+            throw new ArgumentException($"Policy '{policy.Name}' of type '{policyType}' does not contain an AsyncPermission property '{permissionName}' with state type '{typeof(TState)}'.", nameof(permissionName));
 
             static Func<IPolicy, object> buildGetter(Type policyType, System.Reflection.PropertyInfo property)
             {

--- a/src/FluentAuthorization/PolicyContext/IPolicyContext.cs
+++ b/src/FluentAuthorization/PolicyContext/IPolicyContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace FluentAuthorization
 {
@@ -40,5 +41,33 @@ namespace FluentAuthorization
         /// <param name="permissionName">The permission property name to assert.</param>
         /// <returns>An assertion resul.</returns>
         AssertionResult Assert<TState>(string permissionName, TState state);
+
+        /// <summary>
+        /// Assert the selected async permission.
+        /// </summary>
+        /// <param name="select">The async permission to assert.</param>
+        /// <returns>A task representing the async assertion result.</returns>
+        Task<AssertionResult> AssertAsync(Func<T, IAsyncPermission> select);
+
+        /// <summary>
+        /// Assert the selected async permission.
+        /// </summary>
+        /// <param name="permissionName">The permission property name to assert.</param>
+        /// <returns>A task representing the async assertion result.</returns>
+        Task<AssertionResult> AssertAsync(string permissionName);
+
+        /// <summary>
+        /// Assert the selected async permission.
+        /// </summary>
+        /// <param name="select">The async permission to assert.</param>
+        /// <returns>A task representing the async assertion result.</returns>
+        Task<AssertionResult> AssertAsync<TState>(Func<T, IAsyncPermission<TState>> select, TState state);
+
+        /// <summary>
+        /// Assert the selected async permission.
+        /// </summary>
+        /// <param name="permissionName">The permission property name to assert.</param>
+        /// <returns>A task representing the async assertion result.</returns>
+        Task<AssertionResult> AssertAsync<TState>(string permissionName, TState state);
     }
 }

--- a/src/FluentAuthorization/PolicyContext/PolicyContext.cs
+++ b/src/FluentAuthorization/PolicyContext/PolicyContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace FluentAuthorization
 {
@@ -51,6 +52,34 @@ namespace FluentAuthorization
             var permission = PolicyReflector.GetPermission<T, TUser, TResource, TData, TState>(Policy, permissionName);
             var typedPermission = (Policy<TUser, TResource, TData>.Permission<TState>)permission;
             return Policy.Assert(user, Resource, typedPermission, Data, state);
+        }
+
+        public async Task<AssertionResult> AssertAsync(Func<T, IAsyncPermission> select)
+        {
+            var permission = select(Policy);
+            var typedPermission = (Policy<TUser, TResource, TData>.AsyncPermission)permission;
+            return await Policy.AssertAsync(user, Resource, typedPermission, Data);
+        }
+
+        public async Task<AssertionResult> AssertAsync(string permissionName)
+        {
+            var permission = PolicyReflector.GetAsyncPermission<T, TUser, TResource, TData>(Policy, permissionName);
+            var typedPermission = (Policy<TUser, TResource, TData>.AsyncPermission)permission;
+            return await Policy.AssertAsync(user, Resource, typedPermission, Data);
+        }
+
+        public async Task<AssertionResult> AssertAsync<TState>(Func<T, IAsyncPermission<TState>> select, TState state)
+        {
+            var permission = select(Policy);
+            var typedPermission = (Policy<TUser, TResource, TData>.AsyncPermission<TState>)permission;
+            return await Policy.AssertAsync(user, Resource, typedPermission, Data, state);
+        }
+
+        public async Task<AssertionResult> AssertAsync<TState>(string permissionName, TState state)
+        {
+            var permission = PolicyReflector.GetAsyncPermission<T, TUser, TResource, TData, TState>(Policy, permissionName);
+            var typedPermission = (Policy<TUser, TResource, TData>.AsyncPermission<TState>)permission;
+            return await Policy.AssertAsync(user, Resource, typedPermission, Data, state);
         }
     }
 }

--- a/src/FluentAuthorization/PolicyContext/PolicyContextExtensions.cs
+++ b/src/FluentAuthorization/PolicyContext/PolicyContextExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace FluentAuthorization
 {
@@ -53,6 +54,32 @@ namespace FluentAuthorization
             where T : IPolicy
         {
             policy.Assert(select, state).ThrowOnDeny();
+        }
+
+        /// <summary>
+        /// Throw a PolicyAssertionException if the assertion of the selected async permission fails.
+        /// </summary>
+        /// <typeparam name="T">The type of the policy.</typeparam>
+        /// <param name="context">The source context.</param>
+        /// <param name="select">The async permission selector.</param>
+        public static async Task ThrowOnDenyAsync<T>(this IPolicyContext<T> context, Func<T, IAsyncPermission> select)
+            where T : IPolicy
+        {
+            (await context.AssertAsync(select)).ThrowOnDeny();
+        }
+
+        /// <summary>
+        /// Throw a PolicyAssertionException if the assertion of the selected async permission fails.
+        /// </summary>
+        /// <typeparam name="T">The type of the policy.</typeparam>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <param name="context">The source context.</param>
+        /// <param name="select">The async permission selector.</param>
+        /// <param name="state">The state value.</param>
+        public static async Task ThrowOnDenyAsync<T, TState>(this IPolicyContext<T> context, Func<T, IAsyncPermission<TState>> select, TState state)
+            where T : IPolicy
+        {
+            (await context.AssertAsync(select, state)).ThrowOnDeny();
         }
     }
 }

--- a/test/FluentAuthorization.Tests/AsyncAssertionTests.cs
+++ b/test/FluentAuthorization.Tests/AsyncAssertionTests.cs
@@ -1,0 +1,672 @@
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FluentAuthorization.Tests
+{
+    /// <summary>
+    /// Comprehensive tests for async permission delegates
+    /// </summary>
+    public class AsyncAssertionTests
+    {
+        #region Test Models
+
+        public record User(string Id, string Name, bool IsAdmin);
+        public record Document(int Id, string OwnerId);
+
+        private static User CreateUser(string id, string name, bool isAdmin = false) => new User(id, name, isAdmin);
+
+        #endregion
+
+        #region Basic Async Permission Tests
+
+        public class AsyncPermissionPolicy : Policy<User, Document, AsyncPermissionPolicy.Data>
+        {
+            public class Data
+            {
+                public static readonly Data True = new() { Allow = true };
+                public static readonly Data False = new() { Allow = false };
+                public static readonly Data Null = new() { Allow = null };
+
+                public bool? Allow { get; set; }
+                public int DelayMs { get; set; } = 10;
+            }
+
+            public AsyncPermission Read { get; }
+            public AsyncPermission Write { get; }
+
+            public AsyncPermissionPolicy()
+            {
+                // Test Task<bool> return type
+                Read = permissionBuilder.AssertWithAsync(async ctx =>
+                {
+                    await Task.Delay(ctx.Data.DelayMs);
+                    return ctx.Data.Allow == true;
+                })
+                .WithName(nameof(Read))
+                .WithMessage(ctx => $"{ctx.User.Name} cannot read document {ctx.Resource.Id}")
+                .Build();
+
+                // Test Task<bool?> return type (tri-state)
+                Write = permissionBuilder.AssertWithAsync(async ctx =>
+                {
+                    await Task.Delay(ctx.Data.DelayMs);
+                    return ctx.Data.Allow;
+                })
+                .WithName(nameof(Write))
+                .Build();
+            }
+        }
+
+        [Fact]
+        public async Task AsyncPermission_Should_Allow_When_Delegate_Returns_True()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { AsyncPermissionPolicy.Data.True };
+
+            var context = new PolicyContext<AsyncPermissionPolicy, User, Document, AsyncPermissionPolicy.Data>(
+                new AsyncPermissionPolicy(), user, document, data);
+
+            var result = await context.AssertAsync(p => p.Read);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task AsyncPermission_Should_Deny_When_Delegate_Returns_False()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { AsyncPermissionPolicy.Data.False };
+
+            var context = new PolicyContext<AsyncPermissionPolicy, User, Document, AsyncPermissionPolicy.Data>(
+                new AsyncPermissionPolicy(), user, document, data);
+
+            var result = await context.AssertAsync(p => p.Read);
+
+            Assert.False(result);
+            Assert.NotEmpty(result.Failures);
+        }
+
+        [Fact]
+        public async Task AsyncPermission_Should_Return_Undefined_When_Delegate_Returns_Null()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { AsyncPermissionPolicy.Data.Null };
+
+            var context = new PolicyContext<AsyncPermissionPolicy, User, Document, AsyncPermissionPolicy.Data>(
+                new AsyncPermissionPolicy(), user, document, data);
+
+            var result = await context.AssertAsync(p => p.Write);
+
+            // With default TreatUndefinedAsDeny = true, undefined becomes deny
+            Assert.False(result);
+        }
+
+        #endregion
+
+        #region Stateful Async Permission Tests
+
+        public class StatefulAsyncPermissionPolicy : Policy<User, Document, StatefulAsyncPermissionPolicy.Data>
+        {
+            public class Data
+            {
+                public string[] AllowedTargets { get; set; } = Array.Empty<string>();
+                public int DelayMs { get; set; } = 10;
+            }
+
+            public AsyncPermission<string> ShareWith { get; }
+
+            public StatefulAsyncPermissionPolicy()
+            {
+                ShareWith = permissionBuilder.AssertWithAsync<string>(async ctx =>
+                {
+                    await Task.Delay(ctx.Data.DelayMs);
+
+                    if (string.IsNullOrEmpty(ctx.State))
+                        return (bool?)null; // Undefined
+
+                    if (ctx.State == ctx.User.Id)
+                        return false; // Cannot share with self
+
+                    return ctx.Data.AllowedTargets.Contains(ctx.State);
+                })
+                .WithName(nameof(ShareWith))
+                .WithMessage(ctx => $"Cannot share document {ctx.Resource.Id} with user {ctx.State}")
+                .Build();
+            }
+        }
+
+        [Fact]
+        public async Task StatefulAsyncPermission_Should_Allow_When_State_Matches()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { new StatefulAsyncPermissionPolicy.Data { AllowedTargets = new[] { "user2", "user3" } } };
+
+            var context = new PolicyContext<StatefulAsyncPermissionPolicy, User, Document, StatefulAsyncPermissionPolicy.Data>(
+                new StatefulAsyncPermissionPolicy(), user, document, data);
+
+            var result = await context.AssertAsync(p => p.ShareWith, "user2");
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task StatefulAsyncPermission_Should_Deny_When_State_Does_Not_Match()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { new StatefulAsyncPermissionPolicy.Data { AllowedTargets = new[] { "user2" } } };
+
+            var context = new PolicyContext<StatefulAsyncPermissionPolicy, User, Document, StatefulAsyncPermissionPolicy.Data>(
+                new StatefulAsyncPermissionPolicy(), user, document, data);
+
+            var result = await context.AssertAsync(p => p.ShareWith, "user3");
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task StatefulAsyncPermission_Should_Deny_When_Sharing_With_Self()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { new StatefulAsyncPermissionPolicy.Data { AllowedTargets = new[] { "user1" } } };
+
+            var context = new PolicyContext<StatefulAsyncPermissionPolicy, User, Document, StatefulAsyncPermissionPolicy.Data>(
+                new StatefulAsyncPermissionPolicy(), user, document, data);
+
+            var result = await context.AssertAsync(p => p.ShareWith, "user1");
+
+            Assert.False(result);
+        }
+
+        #endregion
+
+        #region Async Permission with Task<AssertionResult>
+
+        public class FullControlAsyncPolicy : Policy<User, Document, FullControlAsyncPolicy.Data>
+        {
+            public class Data
+            {
+                public bool CheckPassed { get; set; }
+                public string[] Reasons { get; set; } = Array.Empty<string>();
+            }
+
+            public FluentAuthorization.IAsyncPermission Access { get; }
+
+            public FullControlAsyncPolicy()
+            {
+                Access = permissionBuilder.AssertWithAsync(async ctx =>
+                {
+                    await Task.Delay(10);
+
+                    if (ctx.Data.CheckPassed)
+                        return ctx.Allow();
+
+                    if (ctx.Data.Reasons.Any())
+                        return ctx.Deny(ctx.Data.Reasons);
+
+                    return ctx.Deny("Access denied");
+                })
+                .WithName(nameof(Access))
+                .Build();
+            }
+        }
+
+        [Fact]
+        public async Task AsyncPermission_With_AssertionResult_Should_Allow()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { new FullControlAsyncPolicy.Data { CheckPassed = true } };
+
+            var context = new PolicyContext<FullControlAsyncPolicy, User, Document, FullControlAsyncPolicy.Data>(
+                new FullControlAsyncPolicy(), user, document, data);
+
+            var result = await context.AssertAsync(p => p.Access);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task AsyncPermission_With_AssertionResult_Should_Deny_With_Multiple_Reasons()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var reasons = new[] { "Insufficient privileges", "Account locked" };
+            var data = new[] { new FullControlAsyncPolicy.Data { CheckPassed = false, Reasons = reasons } };
+
+            var context = new PolicyContext<FullControlAsyncPolicy, User, Document, FullControlAsyncPolicy.Data>(
+                new FullControlAsyncPolicy(), user, document, data);
+
+            var result = await context.AssertAsync(p => p.Access);
+
+            Assert.False(result);
+            Assert.Equal(2, result.Failures.Count());
+        }
+
+        #endregion
+
+        #region Async Permission Aggregation Tests
+
+        public class AsyncAggregationPolicy : Policy<User, Document, AsyncAggregationPolicy.Data>
+        {
+            public class Data
+            {
+                public bool? Allow { get; set; }
+            }
+
+            public FluentAuthorization.IAsyncPermission MultiData { get; }
+
+            public AsyncAggregationPolicy()
+            {
+                MultiData = permissionBuilder.AssertWithAsync(async ctx =>
+                {
+                    await Task.Delay(5);
+                    return ctx.Data.Allow;
+                })
+                .WithName(nameof(MultiData))
+                .Build();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAsyncAggregationTestData))]
+        public async Task Should_Aggregate_Async_Assertions_Correctly(IEnumerable<bool?> allowValues, bool expected)
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = allowValues.Select(a => new AsyncAggregationPolicy.Data { Allow = a });
+
+            var context = new PolicyContext<AsyncAggregationPolicy, User, Document, AsyncAggregationPolicy.Data>(
+                new AsyncAggregationPolicy(), user, document, data);
+
+            var result = await context.AssertAsync(p => p.MultiData);
+
+            Assert.Equal(expected, result);
+        }
+
+        public static IEnumerable<object[]> GetAsyncAggregationTestData()
+            => new object[][] {
+                new object[] { new bool?[] { true, false, null }, false },
+                new object[] { new bool?[] { true, false }, false },
+                new object[] { new bool?[] { true, null }, true },
+                new object[] { new bool?[] { false, null }, false },
+                new object[] { new bool?[] { true, true }, true },
+                new object[] { new bool?[] { false, false }, false },
+                new object[] { new bool?[] { true }, true },
+                new object[] { new bool?[] { false }, false },
+                new object[] { new bool?[] { null }, false }, // Undefined treated as deny by default
+            };
+
+        #endregion
+
+        #region Override Tests for Async Permissions
+
+        public class AsyncOverridePolicy : Policy<User, Document, AsyncOverridePolicy.Data>
+        {
+            public class Data
+            {
+                public bool? Allow { get; set; }
+            }
+
+            public FluentAuthorization.IAsyncPermission Check { get; }
+
+            public AsyncOverridePolicy()
+            {
+                Check = permissionBuilder.AssertWithAsync(async ctx =>
+                {
+                    await Task.Delay(10);
+                    return ctx.Data.Allow == true;
+                })
+                .WithName(nameof(Check))
+                .Build();
+            }
+
+            protected override AssertionResult OverrideAssertion(User user, Document resource, string permissionName, IEnumerable<Data> data)
+            {
+                return user.IsAdmin ? AssertionResult.Success : null;
+            }
+        }
+
+        [Fact]
+        public async Task AsyncPermission_Should_Respect_Override_For_Admin()
+        {
+            var adminUser = CreateUser("admin1", "Admin", isAdmin: true);
+            var document = new Document(42, "user1");
+            var data = new[] { new AsyncOverridePolicy.Data { Allow = false } }; // Would normally deny
+
+            var context = new PolicyContext<AsyncOverridePolicy, User, Document, AsyncOverridePolicy.Data>(
+                new AsyncOverridePolicy(), adminUser, document, data);
+
+            var result = await context.AssertAsync(p => p.Check);
+
+            Assert.True(result); // Override allows admin
+        }
+
+        [Fact]
+        public async Task AsyncPermission_Should_Execute_Delegate_When_Override_Returns_Null()
+        {
+            var regularUser = CreateUser("user1", "Alice", isAdmin: false);
+            var document = new Document(42, "user1");
+            var data = new[] { new AsyncOverridePolicy.Data { Allow = true } };
+
+            var context = new PolicyContext<AsyncOverridePolicy, User, Document, AsyncOverridePolicy.Data>(
+                new AsyncOverridePolicy(), regularUser, document, data);
+
+            var result = await context.AssertAsync(p => p.Check);
+
+            Assert.True(result); // Delegate executes normally
+        }
+
+        #endregion
+
+        #region String-based (Reflection) Async Permission Tests
+
+        [Fact]
+        public async Task Should_Assert_Async_Permission_By_Name()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { AsyncPermissionPolicy.Data.True };
+
+            var context = new PolicyContext<AsyncPermissionPolicy, User, Document, AsyncPermissionPolicy.Data>(
+                new AsyncPermissionPolicy(), user, document, data);
+
+            var result = await context.AssertAsync(nameof(AsyncPermissionPolicy.Read));
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task Should_Assert_Stateful_Async_Permission_By_Name()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { new StatefulAsyncPermissionPolicy.Data { AllowedTargets = new[] { "user2" } } };
+
+            var context = new PolicyContext<StatefulAsyncPermissionPolicy, User, Document, StatefulAsyncPermissionPolicy.Data>(
+                new StatefulAsyncPermissionPolicy(), user, document, data);
+
+            var result = await context.AssertAsync<string>(nameof(StatefulAsyncPermissionPolicy.ShareWith), "user2");
+
+            Assert.True(result);
+        }
+
+        #endregion
+
+        #region Extension Method Tests
+
+        [Fact]
+        public async Task ThrowOnDenyAsync_Should_Not_Throw_When_Allowed()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { AsyncPermissionPolicy.Data.True };
+
+            var context = new PolicyContext<AsyncPermissionPolicy, User, Document, AsyncPermissionPolicy.Data>(
+                new AsyncPermissionPolicy(), user, document, data);
+
+            await context.ThrowOnDenyAsync(p => p.Read);
+
+            // No exception = test passes
+        }
+
+        [Fact]
+        public async Task ThrowOnDenyAsync_Should_Throw_When_Denied()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { AsyncPermissionPolicy.Data.False };
+
+            var context = new PolicyContext<AsyncPermissionPolicy, User, Document, AsyncPermissionPolicy.Data>(
+                new AsyncPermissionPolicy(), user, document, data);
+
+            await Assert.ThrowsAsync<PolicyAssertionException>(async () =>
+                await context.ThrowOnDenyAsync(p => p.Read));
+        }
+
+        [Fact]
+        public async Task ThrowOnDenyAsync_Stateful_Should_Throw_When_Denied()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { new StatefulAsyncPermissionPolicy.Data { AllowedTargets = new[] { "user2" } } };
+
+            var context = new PolicyContext<StatefulAsyncPermissionPolicy, User, Document, StatefulAsyncPermissionPolicy.Data>(
+                new StatefulAsyncPermissionPolicy(), user, document, data);
+
+            await Assert.ThrowsAsync<PolicyAssertionException>(async () =>
+                await context.ThrowOnDenyAsync(p => p.ShareWith, "user3"));
+        }
+
+        #endregion
+
+        #region Custom Async Permission Class Tests
+
+        public class CustomAsyncPermissionPolicy : Policy<User, Document, CustomAsyncPermissionPolicy.Data>
+        {
+            public class Data
+            {
+                public bool CanAccess { get; set; }
+            }
+
+            public class CustomPermission : AsyncPermission
+            {
+                public override string Name => "CustomAsync";
+
+                protected override async Task<AssertionResult> AssertAsync(AssertionContext context)
+                {
+                    await Task.Delay(10);
+
+                    if (context.Data.CanAccess)
+                        return context.Allow();
+
+                    return context.Deny("Custom async permission denied");
+                }
+
+                protected override string BuildMessage(AssertionContext context)
+                {
+                    return $"Custom async permission for {context.User.Name} on document {context.Resource.Id}";
+                }
+            }
+
+            public FluentAuthorization.IAsyncPermission Custom { get; }
+
+            public CustomAsyncPermissionPolicy()
+            {
+                Custom = new CustomPermission();
+            }
+        }
+
+        [Fact]
+        public async Task Custom_Async_Permission_Class_Should_Work()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { new CustomAsyncPermissionPolicy.Data { CanAccess = true } };
+
+            var context = new PolicyContext<CustomAsyncPermissionPolicy, User, Document, CustomAsyncPermissionPolicy.Data>(
+                new CustomAsyncPermissionPolicy(), user, document, data);
+
+            var result = await context.AssertAsync(p => p.Custom);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task Custom_Async_Permission_Class_Should_Deny_With_Custom_Message()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { new CustomAsyncPermissionPolicy.Data { CanAccess = false } };
+
+            var context = new PolicyContext<CustomAsyncPermissionPolicy, User, Document, CustomAsyncPermissionPolicy.Data>(
+                new CustomAsyncPermissionPolicy(), user, document, data);
+
+            var result = await context.AssertAsync(p => p.Custom);
+
+            Assert.False(result);
+            var failure = result.Failures.First();
+            Assert.Equal("Custom async permission denied", failure.Reason);
+            Assert.Contains("Alice", failure.Message);
+            Assert.Contains("42", failure.Message);
+        }
+
+        #endregion
+
+        #region Undefined Behavior Tests
+
+        public class UndefinedAsAllowedAsyncPolicy : Policy<User, Document, UndefinedAsAllowedAsyncPolicy.Data>
+        {
+            public class Data
+            {
+                public bool? Allow { get; set; }
+            }
+
+            public FluentAuthorization.IAsyncPermission Check { get; }
+
+            public UndefinedAsAllowedAsyncPolicy()
+            {
+                TreatUndefinedAsDeny = false;
+
+                Check = permissionBuilder.AssertWithAsync(async ctx =>
+                {
+                    await Task.Delay(10);
+                    return ctx.Data.Allow;
+                })
+                .WithName(nameof(Check))
+                .Build();
+            }
+        }
+
+        [Fact]
+        public async Task AsyncPermission_Should_Allow_Undefined_When_TreatUndefinedAsDeny_Is_False()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { new UndefinedAsAllowedAsyncPolicy.Data { Allow = null } };
+
+            var context = new PolicyContext<UndefinedAsAllowedAsyncPolicy, User, Document, UndefinedAsAllowedAsyncPolicy.Data>(
+                new UndefinedAsAllowedAsyncPolicy(), user, document, data);
+
+            var result = await context.AssertAsync(p => p.Check);
+
+            Assert.True(result); // Undefined treated as allow
+        }
+
+        #endregion
+
+        #region Data Aggregation Before Assertion Tests
+
+        public class AggregateDataBeforeAssertionAsyncPolicy : Policy<User, Document, AggregateDataBeforeAssertionAsyncPolicy.Data>
+        {
+            public class Data
+            {
+                public bool? Allow { get; set; }
+            }
+
+            public FluentAuthorization.IAsyncPermission Check { get; }
+
+            public AggregateDataBeforeAssertionAsyncPolicy()
+            {
+                AggregateDataBeforeAssertion = true;
+
+                Check = permissionBuilder.AssertWithAsync(async ctx =>
+                {
+                    await Task.Delay(10);
+                    return ctx.Data.Allow == true;
+                })
+                .WithName(nameof(Check))
+                .Build();
+            }
+
+            public override Data Aggregate(IEnumerable<Data> data)
+            {
+                // Return first true, else first false, else first null
+                return data.FirstOrDefault(x => x.Allow == true)
+                    ?? data.FirstOrDefault(x => x.Allow == false)
+                    ?? data.FirstOrDefault(x => x.Allow == null)
+                    ?? new();
+            }
+        }
+
+        [Fact]
+        public async Task AsyncPermission_Should_Aggregate_Data_Before_Assertion()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            // Mixed data - aggregation should pick first true
+            var data = new[] {
+                new AggregateDataBeforeAssertionAsyncPolicy.Data { Allow = false },
+                new AggregateDataBeforeAssertionAsyncPolicy.Data { Allow = true },
+                new AggregateDataBeforeAssertionAsyncPolicy.Data { Allow = null }
+            };
+
+            var context = new PolicyContext<AggregateDataBeforeAssertionAsyncPolicy, User, Document, AggregateDataBeforeAssertionAsyncPolicy.Data>(
+                new AggregateDataBeforeAssertionAsyncPolicy(), user, document, data);
+
+            var result = await context.AssertAsync(p => p.Check);
+
+            Assert.True(result);
+        }
+
+        #endregion
+
+        #region Performance and Concurrency Tests
+
+        [Fact]
+        public async Task Multiple_Async_Assertions_Should_Execute_Sequentially()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] {
+                new AsyncPermissionPolicy.Data { Allow = true, DelayMs = 50 },
+                new AsyncPermissionPolicy.Data { Allow = true, DelayMs = 50 }
+            };
+
+            var context = new PolicyContext<AsyncPermissionPolicy, User, Document, AsyncPermissionPolicy.Data>(
+                new AsyncPermissionPolicy(), user, document, data);
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var result = await context.AssertAsync(p => p.Read);
+            sw.Stop();
+
+            Assert.True(result);
+            // Should take at least 100ms (2 x 50ms) if executed sequentially
+            Assert.True(sw.ElapsedMilliseconds >= 90, $"Expected >= 90ms, got {sw.ElapsedMilliseconds}ms");
+        }
+
+        [Fact]
+        public async Task Multiple_Async_Assertions_Can_Run_In_Parallel()
+        {
+            var user = CreateUser("user1", "Alice");
+            var document = new Document(42, "user1");
+            var data = new[] { AsyncPermissionPolicy.Data.True };
+
+            var context = new PolicyContext<AsyncPermissionPolicy, User, Document, AsyncPermissionPolicy.Data>(
+                new AsyncPermissionPolicy(), user, document, data);
+
+            // Run multiple assertions in parallel
+            var tasks = new[]
+            {
+                context.AssertAsync(p => p.Read),
+                context.AssertAsync(p => p.Write),
+                context.AssertAsync(p => p.Read)
+            };
+
+            var results = await Task.WhenAll(tasks);
+
+            Assert.All(results, r => Assert.True(r));
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
#### PR Classification
New feature: Introduces support for asynchronous permissions in the FluentAuthorization library.

#### PR Summary
This pull request adds support for asynchronous permission handling, enhancing the library's capability to manage async operations in security policies.
- Added `IAsyncPermission` and `IAsyncPermission<TState>` interfaces for async permissions.
- Updated `AssertionContext` and `AssertionContext<TState>` to handle async permissions.
- Introduced `AsyncPermission` and `AsyncPermission<TState>` abstract classes for async permission structure.
- Added comprehensive unit tests in `AsyncAssertionTests.cs` to validate async permission functionality.
